### PR TITLE
Add the Metacello adding script (copied from AbstractGPU).

### DIFF
--- a/scripts/tonelToMonticello.st
+++ b/scripts/tonelToMonticello.st
@@ -1,0 +1,24 @@
+|source destination packages goferSource goferDestination|
+source := TonelRepository basicFromUrl: 'tonel://tonel'.
+destination := MCDirectoryRepository new directory: FileSystem workingDirectory / 'mc'.
+
+packages := #(
+    #'FormProceduralLibrary-Core'
+    #'FormProceduralLibrary-Tests'
+    #'FormProceduralLibrary-Samples'
+    #'BaselineOfFormProceduralLibrary'
+).
+
+goferSource := Gofer new repository: source.
+goferDestination := Gofer new repository: destination.
+
+packages do: [:package |
+    goferSource package: package.
+    goferDestination package: package.
+].
+
+goferSource fetch.
+goferDestination push.
+
+"Exit"
+Smalltalk quitPrimitive.

--- a/tonelToMonticello.sh
+++ b/tonelToMonticello.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ ! -e Pharo.image ]; then
+    curl https://get.pharo.org/64/70+vm | bash
+fi
+
+rm -rf pharo-local
+rm -rf mc
+mkdir -p mc
+./pharo Pharo.image st scripts/tonelToMonticello.st


### PR DESCRIPTION
Update tonelToMonticello.sh to use 64-bit Pharo since Rosetta on M1 macos
only works with x86_64 binaries, not i386 ones.